### PR TITLE
MM-52722: Fixed error when accessing property on undefined

### DIFF
--- a/webapp/src/components/live-markdown-plugin/liveMarkdownPlugin.ts
+++ b/webapp/src/components/live-markdown-plugin/liveMarkdownPlugin.ts
@@ -180,7 +180,7 @@ const maintainInlineStyles = (
 
     // If enter was pressed (or the block was otherwise split) we must maintain
     // styles in the previous block as well
-    if (lastChangeType === 'split-block') {
+    if (lastChangeType === 'split-block' && contentState.getBlockBefore(blockKey) !== undefined) {
         const newPrevBlock = mapInlineStyles(
             contentState.getBlockBefore(blockKey)!,
             inlineStyleStrategies,


### PR DESCRIPTION
Closes #8

## What changed
Added a `contentState.getBlockBefore(blockKey) !== undefined` guard in `liveMarkdownPlugin.ts` to prevent a JS error when split-block is triggered on a block with no preceding block (e.g., empty lines in the comments box).

## Test plan
Automated tests pass. See CI for full results.

---
*Generated by Claude Code agent | Upstream reference: #4957*