### PR TITLE
Bug:

### DIFF
--- a/webapp/src/components/cardDetail/comment.scss
+++ b/webapp/src/components/cardDetail/comment.scss
@@ -61,6 +61,7 @@
         }
     }
 
+    .comment-text,
     .comment-text * {
         user-select: text;
     }

--- a/webapp/src/components/markdownEditor.scss
+++ b/webapp/src/components/markdownEditor.scss
@@ -11,10 +11,12 @@
 .MarkdownEditor {
     cursor: text;
 
+    .MarkdownEditorInput,
     .MarkdownEditorInput * {
         user-select: text;
     }
 
+    .octo-editor-preview,
     .octo-editor-preview * {
         user-select: text;
     }


### PR DESCRIPTION
Closes #21

## What changed
Added `.comment-text` and `.octo-editor-preview`/`.MarkdownEditorInput` container selectors to `user-select: text` overrides in comment.scss and markdownEditor.scss so that card comment and description text is selectable despite the global `user-select: none` on `.focalboard-body *`.

## Test plan
Automated tests pass. See CI for full results.

---
*Generated by Claude Code agent | Upstream reference: #5060*