### PR TITLE
fix: broken Dockerfile fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install --no-optional && \
     npm run pack
 
 ### Go build
-FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS gobuild
+FROM golang:1.21.8-bullseye@sha256:81d98548f08e22a59c5c0be814acc0997f3dfd3313487adcf4e1d3d962af3a43 AS gobuild
 
 WORKDIR /go/src/focalboard
 ADD . /go/src/focalboard


### PR DESCRIPTION
Closes #22

## What changed
Updated the Go build base image in `docker/Dockerfile` from `golang:1.18.3` to `golang:1.21.8-bullseye` to match the `go 1.21` / `toolchain go1.21.8` requirement in `server/go.mod`.

## Test plan
Automated tests pass. See CI for full results.

---
*Generated by Claude Code agent | Upstream reference: #5017*