### PR TITLE
Hide horizontal scrollbar during some  board templates

### DIFF
--- a/webapp/src/components/table/table.scss
+++ b/webapp/src/components/table/table.scss
@@ -3,7 +3,7 @@
 .Table {
     margin-top: 16px;
     margin-left: 0 !important;
-    overflow: auto;
+    overflow: hidden;
     position: relative;
     flex: 1;
 


### PR DESCRIPTION
Closes #24

## What changed
Changed `overflow: auto` to `overflow: hidden` in `.Table` CSS class in `webapp/src/components/table/table.scss` to hide the horizontal scrollbar when viewing the table template selector during new board creation.

## Test plan
Automated tests pass. See CI for full results.

---
*Generated by Claude Code agent | Upstream reference: #4708*