### PR TITLE
fix(crash): Guard against empty-string panic when deleting board with malformed attachment

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -355,7 +355,7 @@ func (s *SQLStore) deleteBlock(db sq.BaseRunner, blockID string, modifiedBy stri
 
 func retrieveFileIDFromBlockFieldStorage(id string) string {
 	parts := strings.Split(id, ".")
-	if len(parts) < 1 {
+	if len(parts[0]) < 1 {
 		return ""
 	}
 	return parts[0][1:]

--- a/server/services/store/sqlstore/blocks_test.go
+++ b/server/services/store/sqlstore/blocks_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrieveFileIDFromBlockFieldStorage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string does not panic",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "standard file id with extension",
+			input:    "!abc123.png",
+			expected: "abc123",
+		},
+		{
+			name:     "file id without extension",
+			input:    "!abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "just the prefix character",
+			input:    "!",
+			expected: "",
+		},
+		{
+			name:     "malformed: no prefix character",
+			input:    "abc123.png",
+			expected: "bc123",
+		},
+		{
+			name:     "file id with multiple dots",
+			input:    "!abc123.tar.gz",
+			expected: "abc123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				result := retrieveFileIDFromBlockFieldStorage(tc.input)
+				require.Equal(t, tc.expected, result)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a `panic: slice bounds out of range [1:0]` in `retrieveFileIDFromBlockFieldStorage` that prevented boards from being deleted when they contained blocks with empty or malformed file attachment fields
- Replaces the dead `len(parts) < 1` guard (strings.Split always returns at least 1 element) with the correct `len(parts[0]) < 1` check
- Adds unit tests covering empty, normal, and malformed input

Fixes #4905

## Test plan

- [x] `go test ./services/store/sqlstore/ -run TestRetrieveFileIDFromBlockFieldStorage` passes
- [x] All new test cases (empty string, standard file id, malformed input) pass without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)