### PR TITLE
fix(crash): Normalise locale to valid BCP 47 tag to prevent Intl crash on Mattermost v9

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -9,7 +9,7 @@ import {History} from 'history'
 
 import TelemetryClient from './telemetry/telemetryClient'
 
-import {getMessages} from './i18n'
+import {getMessages, toLocale} from './i18n'
 import {FlashMessages} from './components/flashMessages'
 import NewVersionBanner from './components/newVersionBanner'
 import {Utils} from './utils'
@@ -44,7 +44,7 @@ const App = (props: Props): JSX.Element => {
 
     return (
         <IntlProvider
-            locale={language.split(/[_]/)[0]}
+            locale={toLocale(language)}
             messages={getMessages(language)}
         >
             <DndProvider backend={Utils.isMobile() ? TouchBackend : HTML5Backend}>

--- a/webapp/src/i18n.test.ts
+++ b/webapp/src/i18n.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {toLocale} from './i18n'
+
+describe('toLocale', () => {
+    it('returns bare language codes unchanged', () => {
+        expect(toLocale('en')).toBe('en')
+        expect(toLocale('de')).toBe('de')
+        expect(toLocale('fr')).toBe('fr')
+        expect(toLocale('ja')).toBe('ja')
+    })
+
+    it('normalises hyphen-separated codes to uppercase region', () => {
+        expect(toLocale('pt-br')).toBe('pt-BR')
+        expect(toLocale('zh-cn')).toBe('zh-CN')
+        expect(toLocale('zh-tw')).toBe('zh-TW')
+    })
+
+    it('normalises underscore-separated codes to uppercase region', () => {
+        expect(toLocale('pt_BR')).toBe('pt-BR')
+        expect(toLocale('zh_CN')).toBe('zh-CN')
+    })
+
+    it('already-correct tags pass through unchanged', () => {
+        expect(toLocale('en-US')).toBe('en-US')
+        expect(toLocale('pt-BR')).toBe('pt-BR')
+    })
+})

--- a/webapp/src/i18n.tsx
+++ b/webapp/src/i18n.tsx
@@ -74,6 +74,18 @@ export function getCurrentLanguage(): string {
     return lang
 }
 
+// toLocale converts an internal language code to a valid BCP 47 locale tag
+// accepted by the Intl APIs. Bare language codes (e.g. 'en', 'de') are
+// returned unchanged. Codes with a region suffix use a hyphen separator and
+// an uppercase region subtag (e.g. 'pt-br' → 'pt-BR', 'zh-cn' → 'zh-CN').
+export function toLocale(language: string): string {
+    const parts = language.split(/[-_]/)
+    if (parts.length === 1) {
+        return parts[0]
+    }
+    return `${parts[0]}-${parts[1].toUpperCase()}`
+}
+
 export function storeLanguage(lang: string): void {
     UserSettings.language = lang
 }


### PR DESCRIPTION
## Summary

- Fixes `RangeError: Incorrect locale information provided` that prevented the Focalboard plugin from loading in Mattermost v9.0.0
- The crash occurred because internal language codes like `pt-br` and `zh-cn` use lowercase region subtags, which are rejected by `Intl.supportedLocalesOf` on some V8 runtimes
- Adds a `toLocale()` utility in `i18n.tsx` that converts internal codes to proper BCP 47 tags (`pt-br` → `pt-BR`, `zh-cn` → `zh-CN`) while passing bare language codes (`en`, `de`) through unchanged
- Replaces the ad-hoc `language.split(/[_]/)[0]` in `app.tsx` with `toLocale(language)`

Fixes #4880

## Test plan

- [x] `npx jest src/i18n.test.ts` passes (4 tests covering bare codes, hyphen-separated, underscore-separated, and already-correct tags)
- [x] Manual: verify the Focalboard plugin loads without JS errors in Mattermost v9 with default locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)