### PR TITLE
fix(crash): Guard against undefined options when group-by property type is changed to non-groupable

### DIFF
--- a/webapp/src/boardUtils.ts
+++ b/webapp/src/boardUtils.ts
@@ -7,7 +7,7 @@ function groupCardsByOptions(cards: Card[], optionIds: string[], groupByProperty
     const groups = []
     for (const optionId of optionIds) {
         if (optionId) {
-            const option = groupByProperty?.options.find((o) => o.id === optionId)
+            const option = groupByProperty?.options?.find((o) => o.id === optionId)
             if (option) {
                 const c = cards.filter((o) => optionId === o.fields?.properties[groupByProperty!.id])
                 const group: BoardGroup = {
@@ -22,7 +22,7 @@ function groupCardsByOptions(cards: Card[], optionIds: string[], groupByProperty
             // Empty group
             const emptyGroupCards = cards.filter((card) => {
                 const groupByOptionId = card.fields.properties[groupByProperty?.id || '']
-                return !groupByOptionId || !groupByProperty?.options.find((option) => option.id === groupByOptionId)
+                return !groupByOptionId || !groupByProperty?.options?.find((option) => option.id === groupByOptionId)
             })
             const group: BoardGroup = {
                 option: {id: '', value: `No ${groupByProperty?.name}`, color: ''},
@@ -37,7 +37,7 @@ function groupCardsByOptions(cards: Card[], optionIds: string[], groupByProperty
 function getOptionGroups(cards: Card[], visibleOptionIds: string[], hiddenOptionIds: string[], groupByProperty?: IPropertyTemplate): {visible: BoardGroup[], hidden: BoardGroup[]} {
     let unassignedOptionIds: string[] = []
     if (groupByProperty) {
-        unassignedOptionIds = groupByProperty.options.
+        unassignedOptionIds = (groupByProperty.options ?? []).
             filter((o: IPropertyOption) => !visibleOptionIds.includes(o.id) && !hiddenOptionIds.includes(o.id)).
             map((o: IPropertyOption) => o.id)
     }

--- a/webapp/src/components/workspace.tsx
+++ b/webapp/src/components/workspace.tsx
@@ -119,8 +119,10 @@ function CenterContent(props: Props) {
 
     if (board && !isBoardHidden() && activeView) {
         let property = groupByProperty
-        if ((!property || !propsRegistry.get(property.type).canGroup) && activeView.fields.viewType === 'board') {
-            property = board?.cardProperties.find((o) => propsRegistry.get(o.type).canGroup)
+        if (!property || !propsRegistry.get(property.type).canGroup) {
+            if (activeView.fields.viewType === 'board' || activeView.fields.viewType === 'table') {
+                property = board?.cardProperties.find((o) => propsRegistry.get(o.type).canGroup)
+            }
         }
 
         let displayProperty = dateDisplayProperty


### PR DESCRIPTION
## Summary

- Fixes crash when a board property used as group-by is changed to a non-groupable type (e.g. URL), leaving the `options` field absent on the property object
- In `boardUtils.ts`, adds optional chaining (`?.`) on all `options` accesses inside `groupCardsByOptions` and replaces bare `.options.filter()` with `(groupByProperty.options ?? []).filter()` in `getOptionGroups`
- Extends the non-groupable property fallback in `workspace.tsx` to cover table views in addition to board (kanban) views

Fixes #4845

## Test plan

- [x] Existing workspace tests pass (`npx jest workspace`)
- [x] Manual: create a board with a Status (select) property as group-by, change Status type to URL, navigate to the board — no JS error, board renders in a fallback state

🤖 Generated with [Claude Code](https://claude.com/claude-code)