### PR TITLE
Update centerPanel.scss

### DIFF
--- a/webapp/src/components/centerPanel.scss
+++ b/webapp/src/components/centerPanel.scss
@@ -71,6 +71,8 @@
     > div:nth-child(2) {
         padding: 0 0 0 1px;
         margin-left: 32px;
+        margin-bottom: 5px;
+        margin-right: 5px;
 
         @media (max-width: 768px) {
             margin-left: 0;


### PR DESCRIPTION
#### Summary
  Updated css for .BoardComponent > div:nth-child to add 5px margins on the bottom and right to allow easier scrollbar access

#### Ticket Link
  Fixes https://github.com/officialjaware/focalboard-reborn/issues/372
